### PR TITLE
New distribution [2019.03.28]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: clean dist manpages release pipenv pypi setup
 
+export PIPENV_VENV_IN_PROJECT=1
+
 SHELL   := /usr/local/bin/bash
 DIR     ?= .
 

--- a/contrib/macdaily-archive.rst
+++ b/contrib/macdaily-archive.rst
@@ -6,8 +6,8 @@ macdaily-archive
 MacDaily Log Archive Utility
 ----------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-cleanup-brew.rst
+++ b/contrib/macdaily-cleanup-brew.rst
@@ -6,8 +6,8 @@ macdaily-cleanup-brew
 Homebrew Formula Cache Cleanup
 ------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-cleanup-cask.rst
+++ b/contrib/macdaily-cleanup-cask.rst
@@ -6,8 +6,8 @@ macdaily-cleanup-cask
 Homebrew Cask Cache Cleanup
 ---------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-cleanup-npm.rst
+++ b/contrib/macdaily-cleanup-npm.rst
@@ -6,8 +6,8 @@ macdaily-cleanup-npm
 Node.js Module Cache Cleanup
 ----------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-cleanup-pip.rst
+++ b/contrib/macdaily-cleanup-pip.rst
@@ -6,8 +6,8 @@ macdaily-cleanup-pip
 Python Package Cache Cleanup
 ----------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-cleanup.rst
+++ b/contrib/macdaily-cleanup.rst
@@ -6,8 +6,8 @@ macdaily-cleanup
 macOS Package Cache Cleanup
 ---------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-config.rst
+++ b/contrib/macdaily-config.rst
@@ -6,8 +6,8 @@ macdaily-config
 MacDaily Runtime Configuration Helper
 -------------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-dependency-brew.rst
+++ b/contrib/macdaily-dependency-brew.rst
@@ -6,8 +6,8 @@ macdaily-dependency-brew
 Homebrew Formula Dependency Query
 ---------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-dependency-pip.rst
+++ b/contrib/macdaily-dependency-pip.rst
@@ -6,8 +6,8 @@ macdaily-dependency-pip
 Python Package Dependency Query
 -------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-dependency.rst
+++ b/contrib/macdaily-dependency.rst
@@ -6,8 +6,8 @@ macdaily-dependency
 macOS Package Dependency Query
 ------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-help.rst
+++ b/contrib/macdaily-help.rst
@@ -6,8 +6,8 @@ macdaily-help
 MacDaily Usage Information Manual
 ---------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-install-apm.rst
+++ b/contrib/macdaily-install-apm.rst
@@ -6,8 +6,8 @@ macdaily-install-apm
 Atom Plug-In Automated Installer
 --------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-install-brew.rst
+++ b/contrib/macdaily-install-brew.rst
@@ -6,8 +6,8 @@ macdaily-install-brew
 Homebrew Formula Automated Installer
 ------------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-install-cask.rst
+++ b/contrib/macdaily-install-cask.rst
@@ -6,8 +6,8 @@ macdaily-install-cask
 Homebrew Cask Automated Installer
 ---------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-install-gem.rst
+++ b/contrib/macdaily-install-gem.rst
@@ -6,8 +6,8 @@ macdaily-install-gem
 Ruby Gem Automated Installer
 ----------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-install-mas.rst
+++ b/contrib/macdaily-install-mas.rst
@@ -6,8 +6,8 @@ macdaily-install-mas
 macOS Application Automated Installer
 -------------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-install-npm.rst
+++ b/contrib/macdaily-install-npm.rst
@@ -6,8 +6,8 @@ macdaily-install-npm
 Node.js Module Automated Installer
 ----------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-install-pip.rst
+++ b/contrib/macdaily-install-pip.rst
@@ -6,8 +6,8 @@ macdaily-install-pip
 Python Package Automated Installer
 ----------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-install-system.rst
+++ b/contrib/macdaily-install-system.rst
@@ -6,8 +6,8 @@ macdaily-install-system
 System Software Automated Installer
 -----------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-install.rst
+++ b/contrib/macdaily-install.rst
@@ -6,8 +6,8 @@ macdaily-install
 macOS Package Automated Installer
 ---------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-launch.rst
+++ b/contrib/macdaily-launch.rst
@@ -6,8 +6,8 @@ macdaily-launch
 MacDaily Dependency Launch Helper
 ---------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-logging-apm.rst
+++ b/contrib/macdaily-logging-apm.rst
@@ -6,8 +6,8 @@ macdaily-logging-apm
 Atom Plug-In Logging Automator
 ------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-logging-app.rst
+++ b/contrib/macdaily-logging-app.rst
@@ -6,8 +6,8 @@ macdaily-logging-app
 Mac Application Logging Automator
 ---------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-logging-brew.rst
+++ b/contrib/macdaily-logging-brew.rst
@@ -6,8 +6,8 @@ macdaily-logging-brew
 Homebrew Formula Logging Automator
 ----------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-logging-cask.rst
+++ b/contrib/macdaily-logging-cask.rst
@@ -6,8 +6,8 @@ macdaily-logging-cask
 Homebrew Cask Logging Automator
 -------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-logging-gem.rst
+++ b/contrib/macdaily-logging-gem.rst
@@ -6,8 +6,8 @@ macdaily-logging-gem
 Ruby Gem Logging Automator
 --------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-logging-mas.rst
+++ b/contrib/macdaily-logging-mas.rst
@@ -6,8 +6,8 @@ macdaily-logging-mas
 macOS Application Logging Automator
 -----------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-logging-npm.rst
+++ b/contrib/macdaily-logging-npm.rst
@@ -6,8 +6,8 @@ macdaily-logging-npm
 Node.js Module Logging Automator
 --------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-logging-pip.rst
+++ b/contrib/macdaily-logging-pip.rst
@@ -6,8 +6,8 @@ macdaily-logging-pip
 Python Package Logging Automator
 --------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-logging-tap.rst
+++ b/contrib/macdaily-logging-tap.rst
@@ -6,8 +6,8 @@ macdaily-logging-tap
 Homebrew Tap Logging Automator
 ------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-logging.rst
+++ b/contrib/macdaily-logging.rst
@@ -6,8 +6,8 @@ macdaily-logging
 macOS Package Logging Automator
 -------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-postinstall.rst
+++ b/contrib/macdaily-postinstall.rst
@@ -6,8 +6,8 @@ macdaily-postinstall
 Homebrew Cask Postinstall Automator
 -----------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-reinstall-brew.rst
+++ b/contrib/macdaily-reinstall-brew.rst
@@ -6,8 +6,8 @@ macdaily-reinstall-brew
 Automated Homebrew Formula Reinstaller
 --------------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-reinstall-cask.rst
+++ b/contrib/macdaily-reinstall-cask.rst
@@ -6,8 +6,8 @@ macdaily-reinstall-cask
 Automated Homebrew Cask Reinstaller
 -----------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-reinstall.rst
+++ b/contrib/macdaily-reinstall.rst
@@ -6,8 +6,8 @@ macdaily-reinstall
 Automated macOS Package Reinstaller
 -----------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-uninstall-brew.rst
+++ b/contrib/macdaily-uninstall-brew.rst
@@ -6,8 +6,8 @@ macdaily-uninstall-brew
 Automated Homebrew Formula Uninstaller
 --------------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-uninstall-cask.rst
+++ b/contrib/macdaily-uninstall-cask.rst
@@ -6,8 +6,8 @@ macdaily-uninstall-cask
 Automated Homebrew Cask Uninstaller
 -----------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-uninstall-pip.rst
+++ b/contrib/macdaily-uninstall-pip.rst
@@ -6,8 +6,8 @@ macdaily-uninstall-pip
 Automated Python Package Uninstaller
 ------------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-uninstall.rst
+++ b/contrib/macdaily-uninstall.rst
@@ -6,8 +6,8 @@ macdaily-uninstall
 Automated macOS Package Uninstaller
 -----------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-update-apm.rst
+++ b/contrib/macdaily-update-apm.rst
@@ -6,8 +6,8 @@ macdaily-update-apm
 Atom Plug-In Update Automator
 -----------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-update-brew.rst
+++ b/contrib/macdaily-update-brew.rst
@@ -6,8 +6,8 @@ macdaily-update-brew
 Homebrew Formula Update Automator
 ---------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-update-cask.rst
+++ b/contrib/macdaily-update-cask.rst
@@ -6,8 +6,8 @@ macdaily-update-cask
 Homebrew Cask Update Automator
 ------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-update-gem.rst
+++ b/contrib/macdaily-update-gem.rst
@@ -6,8 +6,8 @@ macdaily-update-gem
 Ruby Gem Update Automator
 -------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-update-mas.rst
+++ b/contrib/macdaily-update-mas.rst
@@ -6,8 +6,8 @@ macdaily-update-mas
 macOS Application Update Automator
 ----------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-update-npm.rst
+++ b/contrib/macdaily-update-npm.rst
@@ -6,8 +6,8 @@ macdaily-update-npm
 Node.js Module Update Automator
 -------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-update-pip.rst
+++ b/contrib/macdaily-update-pip.rst
@@ -6,8 +6,8 @@ macdaily-update-pip
 Python Package Update Automator
 -------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-update-system.rst
+++ b/contrib/macdaily-update-system.rst
@@ -6,8 +6,8 @@ macdaily-update-system
 System Software Update Automator
 --------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily-update.rst
+++ b/contrib/macdaily-update.rst
@@ -6,8 +6,8 @@ macdaily-update
 macOS Package Update Automator
 ------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/contrib/macdaily.rst
+++ b/contrib/macdaily.rst
@@ -6,8 +6,8 @@ macdaily
 macOS Automated Package Manager
 -------------------------------
 
-:Version: v2019.3.12
-:Date: March 12, 2019
+:Version: v2019.3.28
+:Date: March 28, 2019
 :Manual section: 8
 :Author:
     Jarry Shaw, a newbie programmer, is the author, owner and maintainer

--- a/setup-formula.py
+++ b/setup-formula.py
@@ -102,8 +102,6 @@ class Macdaily < Formula
     {DEVEL}
   end
 
-  bottle :unneeded
-
   option "without-config", "Build without config modification support"
   option "without-tree", "Build without tree format support"
   option "without-ptyng", "Build without alternative PTY support"

--- a/setup-formula.py
+++ b/setup-formula.py
@@ -149,7 +149,7 @@ class Macdaily < Formula
       end
     end
 
-    version = `#{{libexec}}/"bin/python" -c "print('%s.%s' % __import__('sys').version_info[:2])"`
+    version = Language::Python.major_minor_version "python3"
     if version =~ /3.4/
       %w[pathlib2 six subprocess32].each do |r|
         venv.pip_install resource(r)
@@ -164,7 +164,7 @@ class Macdaily < Formula
     cp comp_path, bash_comp
     bash_completion.install bash_comp
 
-    man_path = Pathname.glob(libexec/"lib/python?.?/site-packages/macdaily/man/*.1")
+    man_path = Pathname.glob(libexec/"lib/python#{{version}}/site-packages/macdaily/man/*.1")
     dir_name = File.dirname man_path[0]
     dest = File.join(dir_name, "temp.1")
 

--- a/setup-formula.py
+++ b/setup-formula.py
@@ -180,10 +180,14 @@ class Macdaily < Formula
     f.write <<~EOS
       # -*- coding: utf-8 -*-
 
-      from macdaily.cmd.launch import launch_askpass, launch_confirm
+      from macdaily.cmd.config import parse_config
+      from macdaily.cmd.launch import launch_askpass, launch_confirm, launch_daemons
 
-      launch_askpass(quiet=True, verbose=True)
-      launch_confirm(quiet=True, verbose=True)
+      launch_askpass(quiet=True, verbose=False)
+      launch_confirm(quiet=True, verbose=False)
+
+      config = parse_config(quiet=True, verbose=False)
+      launch_daemons(config, 'null', quiet=True, verbose=False)
     EOS
     f.close
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ can easily work around and manage packages out of no pain using **MacDaily**.
 """
 
 # version string
-__version__ = '2019.3.12'
+__version__ = '2019.3.28'
 # context = pkg_resources.resource_string(__name__, 'macdaily/util/const/macro.py')
 # for line in context.splitlines():
 #     match = re.match(rb"VERSION = '(.*)'", line)

--- a/src/cls/update/mas.py
+++ b/src/cls/update/mas.py
@@ -44,8 +44,10 @@ class MasUpdate(MasCommand, UpdateCommand):
 
             _temp_pkgs = list()
             for line in filter(None, context.strip().splitlines()):
-                content = line.split()
-                _temp_pkgs.append((content[0], content[1:-1]))
+                text = line.split(maxsplit=1)
+                code = text[0]
+                name = re.sub(r'\(.*?\)', r'', text[1]).strip()
+                _temp_pkgs.append((code, name))
             self._var__temp_pkgs = set(_temp_pkgs)  # pylint: disable=attribute-defined-outside-init
         finally:
             with open(self._file, 'a') as file:

--- a/src/cmd/archive.py
+++ b/src/cmd/archive.py
@@ -52,24 +52,26 @@ def make_archive(config, mode, today, zipfile=True, quiet=False, verbose=False, 
                     print_text(absname, logfile, redirect=verbose)
         shutil.rmtree(absdir)
 
-    this_version = distutils.version.StrictVersion(VERSION)  # pylint: disable=no-member
-    for entry in os.scandir(os.path.join(get_logdir(), 'misc')):
-        if not entry.is_dir:
-            continue
-        try:
-            that_version = distutils.version.StrictVersion(entry.name)  # pylint: disable=no-member
-            if this_version <= that_version:
+    misc_path = os.path.join(get_logdir(), 'misc')
+    if os.path.isdir(misc_path):
+        this_version = distutils.version.StrictVersion(VERSION)  # pylint: disable=no-member
+        for entry in os.scandir(misc_path):
+            if not entry.is_dir:
                 continue
-        except ValueError:
-            pass
-        glob_list = glob.glob(os.path.join(entry.path, '*.log'))
-        if glob_list:
-            tarname = os.path.join(arcpath, f'{entry.name}.tar.gz')
-            with tarfile.open(tarname, 'w:gz') as gz:
-                for absname in glob_list:
-                    arcname = os.path.split(absname)[1]
-                    gz.add(absname, arcname)
-        shutil.rmtree(entry.path)
+            try:
+                that_version = distutils.version.StrictVersion(entry.name)  # pylint: disable=no-member
+                if this_version <= that_version:
+                    continue
+            except ValueError:
+                pass
+            glob_list = glob.glob(os.path.join(entry.path, '*.log'))
+            if glob_list:
+                tarname = os.path.join(arcpath, f'{entry.name}.tar.gz')
+                with tarfile.open(tarname, 'w:gz') as gz:
+                    for absname in glob_list:
+                        arcname = os.path.split(absname)[1]
+                        gz.add(absname, arcname)
+            shutil.rmtree(entry.path)
 
     text = f'Moving ancient archives into {under}XZ Compressed Archives{reset}'
     print_info(text, logfile, redirect=quiet)

--- a/src/man/macdaily-archive.1
+++ b/src/man/macdaily-archive.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-ARCHIVE 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-ARCHIVE 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-archive \- MacDaily Log Archive Utility
 .

--- a/src/man/macdaily-cleanup-brew.1
+++ b/src/man/macdaily-cleanup-brew.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-CLEANUP-BREW 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-CLEANUP-BREW 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-cleanup-brew \- Homebrew Formula Cache Cleanup
 .

--- a/src/man/macdaily-cleanup-cask.1
+++ b/src/man/macdaily-cleanup-cask.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-CLEANUP-CASK 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-CLEANUP-CASK 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-cleanup-cask \- Homebrew Cask Cache Cleanup
 .

--- a/src/man/macdaily-cleanup-npm.1
+++ b/src/man/macdaily-cleanup-npm.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-CLEANUP-NPM 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-CLEANUP-NPM 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-cleanup-npm \- Node.js Module Cache Cleanup
 .

--- a/src/man/macdaily-cleanup-pip.1
+++ b/src/man/macdaily-cleanup-pip.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-CLEANUP-PIP 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-CLEANUP-PIP 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-cleanup-pip \- Python Package Cache Cleanup
 .

--- a/src/man/macdaily-cleanup.1
+++ b/src/man/macdaily-cleanup.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-CLEANUP 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-CLEANUP 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-cleanup \- macOS Package Cache Cleanup
 .

--- a/src/man/macdaily-config.1
+++ b/src/man/macdaily-config.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-CONFIG 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-CONFIG 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-config \- MacDaily Runtime Configuration Helper
 .

--- a/src/man/macdaily-dependency-brew.1
+++ b/src/man/macdaily-dependency-brew.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-DEPENDENCY-BREW 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-DEPENDENCY-BREW 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-dependency-brew \- Homebrew Formula Dependency Query
 .

--- a/src/man/macdaily-dependency-pip.1
+++ b/src/man/macdaily-dependency-pip.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-DEPENDENCY-PIP 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-DEPENDENCY-PIP 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-dependency-pip \- Python Package Dependency Query
 .

--- a/src/man/macdaily-dependency.1
+++ b/src/man/macdaily-dependency.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-DEPENDENCY 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-DEPENDENCY 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-dependency \- macOS Package Dependency Query
 .

--- a/src/man/macdaily-help.1
+++ b/src/man/macdaily-help.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-HELP 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-HELP 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-help \- MacDaily Usage Information Manual
 .

--- a/src/man/macdaily-install-apm.1
+++ b/src/man/macdaily-install-apm.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-INSTALL-APM 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-INSTALL-APM 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-install-apm \- Atom Plug-In Automated Installer
 .

--- a/src/man/macdaily-install-brew.1
+++ b/src/man/macdaily-install-brew.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-INSTALL-BREW 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-INSTALL-BREW 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-install-brew \- Homebrew Formula Automated Installer
 .

--- a/src/man/macdaily-install-cask.1
+++ b/src/man/macdaily-install-cask.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-INSTALL-CASK 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-INSTALL-CASK 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-install-cask \- Homebrew Cask Automated Installer
 .

--- a/src/man/macdaily-install-gem.1
+++ b/src/man/macdaily-install-gem.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-INSTALL-GEM 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-INSTALL-GEM 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-install-gem \- Ruby Gem Automated Installer
 .

--- a/src/man/macdaily-install-mas.1
+++ b/src/man/macdaily-install-mas.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-INSTALL-MAS 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-INSTALL-MAS 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-install-mas \- macOS Application Automated Installer
 .

--- a/src/man/macdaily-install-npm.1
+++ b/src/man/macdaily-install-npm.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-INSTALL-NPM 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-INSTALL-NPM 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-install-npm \- Node.js Module Automated Installer
 .

--- a/src/man/macdaily-install-pip.1
+++ b/src/man/macdaily-install-pip.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-INSTALL-PIP 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-INSTALL-PIP 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-install-pip \- Python Package Automated Installer
 .

--- a/src/man/macdaily-install-system.1
+++ b/src/man/macdaily-install-system.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-INSTALL-SYSTEM 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-INSTALL-SYSTEM 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-install-system \- System Software Automated Installer
 .

--- a/src/man/macdaily-install.1
+++ b/src/man/macdaily-install.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-INSTALL 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-INSTALL 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-install \- macOS Package Automated Installer
 .

--- a/src/man/macdaily-launch.1
+++ b/src/man/macdaily-launch.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-LAUNCH 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-LAUNCH 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-launch \- MacDaily Dependency Launch Helper
 .

--- a/src/man/macdaily-logging-apm.1
+++ b/src/man/macdaily-logging-apm.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-LOGGING-APM 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-LOGGING-APM 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-logging-apm \- Atom Plug-In Logging Automator
 .

--- a/src/man/macdaily-logging-app.1
+++ b/src/man/macdaily-logging-app.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-LOGGING-APP 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-LOGGING-APP 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-logging-app \- Mac Application Logging Automator
 .

--- a/src/man/macdaily-logging-brew.1
+++ b/src/man/macdaily-logging-brew.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-LOGGING-BREW 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-LOGGING-BREW 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-logging-brew \- Homebrew Formula Logging Automator
 .

--- a/src/man/macdaily-logging-cask.1
+++ b/src/man/macdaily-logging-cask.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-LOGGING-CASK 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-LOGGING-CASK 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-logging-cask \- Homebrew Cask Logging Automator
 .

--- a/src/man/macdaily-logging-gem.1
+++ b/src/man/macdaily-logging-gem.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-LOGGING-GEM 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-LOGGING-GEM 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-logging-gem \- Ruby Gem Logging Automator
 .

--- a/src/man/macdaily-logging-mas.1
+++ b/src/man/macdaily-logging-mas.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-LOGGING-MAS 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-LOGGING-MAS 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-logging-mas \- macOS Application Logging Automator
 .

--- a/src/man/macdaily-logging-npm.1
+++ b/src/man/macdaily-logging-npm.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-LOGGING-NPM 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-LOGGING-NPM 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-logging-npm \- Node.js Module Logging Automator
 .

--- a/src/man/macdaily-logging-pip.1
+++ b/src/man/macdaily-logging-pip.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-LOGGING-PIP 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-LOGGING-PIP 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-logging-pip \- Python Package Logging Automator
 .

--- a/src/man/macdaily-logging-tap.1
+++ b/src/man/macdaily-logging-tap.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-LOGGING-TAP 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-LOGGING-TAP 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-logging-tap \- Homebrew Tap Logging Automator
 .

--- a/src/man/macdaily-logging.1
+++ b/src/man/macdaily-logging.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-LOGGING 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-LOGGING 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-logging \- macOS Package Logging Automator
 .

--- a/src/man/macdaily-postinstall.1
+++ b/src/man/macdaily-postinstall.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-POSTINSTALL 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-POSTINSTALL 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-postinstall \- Homebrew Cask Postinstall Automator
 .

--- a/src/man/macdaily-reinstall-brew.1
+++ b/src/man/macdaily-reinstall-brew.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-REINSTALL-BREW 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-REINSTALL-BREW 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-reinstall-brew \- Automated Homebrew Formula Reinstaller
 .

--- a/src/man/macdaily-reinstall-cask.1
+++ b/src/man/macdaily-reinstall-cask.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-REINSTALL-CASK 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-REINSTALL-CASK 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-reinstall-cask \- Automated Homebrew Cask Reinstaller
 .

--- a/src/man/macdaily-reinstall.1
+++ b/src/man/macdaily-reinstall.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-REINSTALL 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-REINSTALL 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-reinstall \- Automated macOS Package Reinstaller
 .

--- a/src/man/macdaily-uninstall-brew.1
+++ b/src/man/macdaily-uninstall-brew.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-UNINSTALL-BREW 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-UNINSTALL-BREW 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-uninstall-brew \- Automated Homebrew Formula Uninstaller
 .

--- a/src/man/macdaily-uninstall-cask.1
+++ b/src/man/macdaily-uninstall-cask.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-UNINSTALL-CASK 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-UNINSTALL-CASK 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-uninstall-cask \- Automated Homebrew Cask Uninstaller
 .

--- a/src/man/macdaily-uninstall-pip.1
+++ b/src/man/macdaily-uninstall-pip.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-UNINSTALL-PIP 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-UNINSTALL-PIP 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-uninstall-pip \- Automated Python Package Uninstaller
 .

--- a/src/man/macdaily-uninstall.1
+++ b/src/man/macdaily-uninstall.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-UNINSTALL 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-UNINSTALL 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-uninstall \- Automated macOS Package Uninstaller
 .

--- a/src/man/macdaily-update-apm.1
+++ b/src/man/macdaily-update-apm.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-UPDATE-APM 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-UPDATE-APM 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-update-apm \- Atom Plug-In Update Automator
 .

--- a/src/man/macdaily-update-brew.1
+++ b/src/man/macdaily-update-brew.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-UPDATE-BREW 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-UPDATE-BREW 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-update-brew \- Homebrew Formula Update Automator
 .

--- a/src/man/macdaily-update-cask.1
+++ b/src/man/macdaily-update-cask.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-UPDATE-CASK 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-UPDATE-CASK 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-update-cask \- Homebrew Cask Update Automator
 .

--- a/src/man/macdaily-update-gem.1
+++ b/src/man/macdaily-update-gem.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-UPDATE-GEM 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-UPDATE-GEM 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-update-gem \- Ruby Gem Update Automator
 .

--- a/src/man/macdaily-update-mas.1
+++ b/src/man/macdaily-update-mas.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-UPDATE-MAS 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-UPDATE-MAS 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-update-mas \- macOS Application Update Automator
 .

--- a/src/man/macdaily-update-npm.1
+++ b/src/man/macdaily-update-npm.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-UPDATE-NPM 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-UPDATE-NPM 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-update-npm \- Node.js Module Update Automator
 .

--- a/src/man/macdaily-update-pip.1
+++ b/src/man/macdaily-update-pip.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-UPDATE-PIP 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-UPDATE-PIP 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-update-pip \- Python Package Update Automator
 .

--- a/src/man/macdaily-update-system.1
+++ b/src/man/macdaily-update-system.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-UPDATE-SYSTEM 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-UPDATE-SYSTEM 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-update-system \- System Software Update Automator
 .

--- a/src/man/macdaily-update.1
+++ b/src/man/macdaily-update.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY-UPDATE 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY-UPDATE 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily-update \- macOS Package Update Automator
 .

--- a/src/man/macdaily.1
+++ b/src/man/macdaily.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MACDAILY 8 "March 12, 2019" "v2019.3.12" ""
+.TH MACDAILY 8 "March 28, 2019" "v2019.3.28" ""
 .SH NAME
 macdaily \- macOS Automated Package Manager
 .

--- a/src/util/const/macro.py
+++ b/src/util/const/macro.py
@@ -10,7 +10,7 @@ import sys
 from macdaily.util.compat import pathlib
 
 # version string
-VERSION = '2019.3.12'
+VERSION = '2019.3.28'
 
 # terminal commands
 PYTHON = sys.executable         # Python version


### PR DESCRIPTION
* when calling `macdaily.cmd.archive.make_archive`, `${MACDAILY_LOGDIR}/misc` not exists
* run `macdaily.cmd.launch.launch_daemons` in Homebrew postinstall process
* consider adding a new environ `NO_SUDO` or `NULL_PASSWORD` to disable use of `sudo` and/or request for password
* bugfix in `macdaily.cls.update.mas.MasUpdate`
* moved venv in project
* update `setup-formula.py`
